### PR TITLE
Set MSVC cflags on Cygwin when the compiler is not GCC

### DIFF
--- a/configure
+++ b/configure
@@ -5763,9 +5763,12 @@ generic/tkbltDecls.h
     done
 
 
-#if test "windows" = "${TEA_PLATFORM}"; then
-#TEA_ADD_CFLAGS([-TP -EHsc -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES])
-#fi
+if test "${TEA_PLATFORM}" = "windows" -a "$GCC" != "yes"; then
+
+    PKG_CFLAGS="$PKG_CFLAGS -TP -EHsc -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES"
+
+
+fi
 
     vars="tkbltStubLib.C"
     for i in $vars; do

--- a/configure.ac
+++ b/configure.ac
@@ -128,9 +128,9 @@ generic/tkbltDecls.h
 ])
 TEA_ADD_INCLUDES([])
 TEA_ADD_LIBS([-lstdc++])
-#if test "windows" = "${TEA_PLATFORM}"; then
-#TEA_ADD_CFLAGS([-TP -EHsc -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES])
-#fi
+if test "${TEA_PLATFORM}" = "windows" -a "$GCC" != "yes"; then
+TEA_ADD_CFLAGS([-TP -EHsc -D_CRT_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES])
+fi
 TEA_ADD_STUB_SOURCES([tkbltStubLib.C])
 TEA_ADD_TCL_SOURCES([library/graph.tcl])
 


### PR DESCRIPTION
The GCC variable is set by autoconf and inspected by TEA for this same purpose.

Please test on a CYGWIN gcc build.