### PR TITLE
Add missing include defining NAN

### DIFF
--- a/generic/tkbltVecCmd.C
+++ b/generic/tkbltVecCmd.C
@@ -57,6 +57,7 @@
 #include "tkbltOp.h"
 #include "tkbltNsUtil.h"
 #include "tkbltSwitch.h"
+#include "tkbltInt.h"
 
 using namespace Blt;
 


### PR DESCRIPTION
Fixes problem introduced by 95101fc9f957cb4c3eee8b56b455e8b1f883e014
(Interpret empty strings as NaN) when compiling with MSVC.