### PR TITLE
Load graph.tcl when the package is loaded

### DIFF
--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -2,4 +2,4 @@
 # Tcl package index file
 #
 package ifneeded @PACKAGE_NAME@ @PACKAGE_VERSION@ \
-    [list load [file join $dir @PKG_LIB_FILE@] @PACKAGE_NAME@]
+    [list load [file join $dir @PKG_LIB_FILE@] @PACKAGE_NAME@]\n[list source [file join $dir graph.tcl]]


### PR DESCRIPTION
This patch enables the use of tkblt as a Tcl package. Otherwise, some commands (which are used f.e. in saods9) are not accessible:

    % package require tkblt
    3.2
    % blt::RemoveBindTag
    invalid command name "blt::RemoveBindTag"

This patch was [used in the Debian revision 3.2.8-1](https://salsa.debian.org/tcltk-team/tkblt/blob/debian/3.2.8-1/debian/patches/Load-graph.tcl-when-the-package-is-loaded.patch), and is proposed as [update to the Ubuntu package](https://bugs.launchpad.net/ubuntu/+source/tkblt/+bug/1772905).